### PR TITLE
Add 3 RawDraftContentState to HTML exporters

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@
 * [BackDraft.js](https://github.com/evanc/backdraft-js) - Function to turn a rawContentBlock into a marked-up string.
 * [Draft.js Exporter](https://github.com/rkpasia/draft-js-exporter) - Export and format the content from Draft.js.
 * [Draft.js: Export ContentState to HTML](https://github.com/sstur/draft-js-export-html) - Export ContentState to HTML. 
+* [Redraft](https://github.com/lokiuz/redraft) - Renders the result of Draft.js convertToRaw using provided callbacks, works well with React
+* [(Ruby) Draft.js exporter](https://github.com/ignitionworks/draftjs_exporter) - Export Draft.js content state into HTML.
+* [(Python) Draft.js exporter](https://github.com/springload/draftjs_exporter) - Library to convert Draft.js raw ContentState to HTML
 * [Draft.js AST Exporter](https://github.com/icelab/draft-js-ast-exporter) - Export content into an abstract syntax tree (AST).
 * [Draft.js AST Importer](https://github.com/icelab/draft-js-ast-importer)- Emport an abstract syntax tree (AST) output from the companion draft-js-ast-exporter.
 * [Draft.js Multidecorators](https://github.com/SamyPesse/draftjs-multidecorators) - Combine multiple decorators.


### PR DESCRIPTION
One JS, one Ruby, one Python.

I'm working on the Python one as part of a CMS project, and used the other two as sources of inspiration. I believe this would be useful for other people looking at doing the same kind of work.