### PR TITLE
Add Markdown Shortcuts Plugin under Draft.js Plugins  

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
   - [Counter](https://www.draft-js-plugins.com/plugin/counter) - Character, word & line counting.
   - [Autolist](https://github.com/icelab/draft-js-autolist-plugin) - Automatic unordered/ordered list creation.
   - [Block Breakout](https://github.com/icelab/draft-js-block-breakout-plugin) - Break out of block types as you type.
+  - [Markdown Shortcuts](https://github.com/ngs/draft-js-markdown-shortcuts-plugin/) - Markdown syntax shortcuts.
   - [Single Line](https://github.com/icelab/draft-js-single-line-plugin) - Restrict to a single line of input.
   - [RichButtons](https://github.com/jasonphillips/draft-js-richbuttons-plugin) - Add and customize rich formatting buttons.
 * [React-RTE](https://github.com/sstur/react-rte/) - A full-featured textarea replacement similar to CKEditor or TinyMCE.


### PR DESCRIPTION
![screenshort](https://github.com/ngs/draft-js-markdown-shortcuts-plugin/blob/master/screen.gif?raw=true)

repository: https://github.com/ngs/draft-js-markdown-shortcuts-plugin/
demo: https://ngs.github.io/draft-js-markdown-shortcuts-plugin