### PR TITLE
Add usage in production: Wagtail

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@
 * [HKW Technosphere Magazine](https://technosphere-magazine.hkw.de/)
 * [Douban Read](https://read.douban.com/editor_ng)
 * [Dooly](https://www.dooly.ai)
+* [Wagtail](https://wagtail.io/)
 
 ## License
 


### PR DESCRIPTION
[Wagtail](https://github.com/wagtail/wagtail) is now using Draft.js for its default rich text editor in the latest release. The [Wagtail 2.0 release](https://wagtail.io/blog/wagtail-2/) post has some more details, and I'll probably write more Draft.js-focused posts.

The link I added just points to Wagtail's marketing website – Draft.js is used inside of the CMS for rich text content, so it won't be publicly accessible. Here is a [repository of sites made with Wagtail](https://madewithwagtail.org/) if anyone wants to know which sites / companies are involved. Other "big names" who will indirectly soon be using Draft.js "in production" (once they upgrade their Wagtail sites) include _Google, NASA, the NHS, Oxfam, Mozilla, governments, universities_.