### PR TITLE
Add Draftail Playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@
 * [REACTing Codepen Comment Editor - Draft.js](https://codepen.io/rkpasia/full/jqbrpq)
 * [Draft.js Examples - A Heroku app w/ several example Draft.js Editors from different projects](http://draftjs-examples.herokuapp.com/)
 * [Draft-js Samples - An app with examples and code explanations](https://github.com/Mair/react-meetup-draftjs)
+* [Draftail Playground](https://draftail-playground.herokuapp.com/) – Wagtail’s Draft.js dependencies as a standalone demo.
 
 ## Playgrounds for Examples from Official Repository (v.0.10.0)
 * [Rich Text Editor](https://codepen.io/Kiwka/pen/YNYvyG)


### PR DESCRIPTION
https://draftail-playground.herokuapp.com/

This is a combination of all of the Draft.js-related projects I've made for Wagtail, as a standalone demo. The editor is [Draftail](https://github.com/springload/draftail), and HTML export is done with the Python [Draft.js exporter](https://github.com/springload/draftjs_exporter).