### PR TITLE
Add usage in production: Patreon

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@
 * [Douban Read](https://read.douban.com/editor_ng)
 * [Dooly](https://www.dooly.ai)
 * [Wagtail](https://wagtail.io/)
+* [Patreon](https://www.patreon.com/)
 
 ## License
 


### PR DESCRIPTION
I stumbled upon this and thought it was worth sharing. They use it for the "Post" editor which is available to creators:

![patreon-draftjs](https://user-images.githubusercontent.com/877585/41003151-aa2a5ec4-691e-11e8-9431-dffbd4fe7199.png)

It doesn’t seem to be used elsewhere on the site.